### PR TITLE
Destructure `components` props

### DIFF
--- a/src/components/ui/calendar.tsx
+++ b/src/components/ui/calendar.tsx
@@ -64,6 +64,7 @@ function Calendar({
   showYearSwitcher = true,
   yearRange = 12,
   numberOfMonths,
+  components,
   ...props
 }: CalendarProps) {
   const [navView, setNavView] = React.useState<NavView>("days")
@@ -232,6 +233,7 @@ function Calendar({
             {...props}
           />
         ),
+        ...components,
       }}
       numberOfMonths={columnsDisplayed}
       {...props}


### PR DESCRIPTION
This is in order to not override all the default components if we add some.