### PR TITLE
fix: :bug: correct typo in README and page.tsx for month label

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,4 +11,4 @@
 ## Introduction
 
 This custom shadcn component aims to provide a more advanced alternative to the default date picker component. It is built on top of the react-day-picker library, which provides a wide range of customization options.
-In the demo above, notice that you can click on the moth label at the top to change the view to years.
+In the demo above, notice that you can click on the month label at the top to change the view to years.

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -45,7 +45,7 @@ export default function Home() {
           version 9, which is not compatible with the current shadcn date picker
           component.
           <br />
-          In the demo above, notice that you can click on the moth label at the
+          In the demo above, notice that you can click on the month label at the
           top to change the view to years.
         </p>
       </section>


### PR DESCRIPTION
fixed a small typo for month in both the main page and readme