### PR TITLE
fix(calendar): add missing onNextClick prop to Nav component

### DIFF
--- a/src/components/ui/calendar.tsx
+++ b/src/components/ui/calendar.tsx
@@ -209,6 +209,7 @@ function Calendar({
             startMonth={startMonth}
             endMonth={endMonth}
             onPrevClick={onPrevClick}
+            onNextClick={onNextClick}
           />
         ),
         CaptionLabel: (props) => (


### PR DESCRIPTION
- The `onNextClick` prop was passed to the `Calendar` component but was not being passed again to the `Nav` component.
- The fix passes down the `onNextClick ` prop to the `Nav` component.